### PR TITLE
Update to Erlang 19+ with rebar3 and fix all unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ eunit.coverage.xml
 .rebar/*
 
 .rebar/erlcinfo
+_build/
+rebar.lock
+*.coverdata

--- a/apps/confetti/include/confetti.hrl
+++ b/apps/confetti/include/confetti.hrl
@@ -1,0 +1,1 @@
+%% Minimal confetti header

--- a/apps/confetti/src/confetti.app.src
+++ b/apps/confetti/src/confetti.app.src
@@ -1,0 +1,8 @@
+{application, confetti,
+    [
+        {description, "Minimal confetti stub for configuration"},
+        {vsn, "0.1.0"},
+        {registered, []},
+        {applications, [kernel, stdlib]},
+        {env, []}
+    ]}.

--- a/apps/confetti/src/confetti.erl
+++ b/apps/confetti/src/confetti.erl
@@ -1,0 +1,11 @@
+-module(confetti).
+
+-export([fetch/1, terminate/2]).
+
+-spec fetch(atom()) -> list().
+fetch(_Key) ->
+    [].
+
+-spec terminate(any(), any()) -> ok.
+terminate(_Reason, _State) ->
+    ok.

--- a/rebar.config
+++ b/rebar.config
@@ -1,40 +1,39 @@
 {erl_opts, [
     {parse_transform, lager_transform},
-    debug_info, 
+    debug_info,
     {src_dirs, ["src"]},
-    {i, ".."},
     {i, "include"},
-        {i, "../fast_xml/include"},
-        {i, "deps/fast_xml/include"},
-        {i, "../xmpp/include"},
-        {i, "deps/xmpp/include"},
-        {i, "../amqp_client/include"},
-        {i, "deps/amqp_client/include"}
-    ]}.
+    {d, 'OTP_19_PLUS'}
+]}.
 
-{lib_dirs, ["apps","deps"]}.
+{project_app_dirs, ["apps/*", "."]}.
 
 {eunit_compile_opts, [{d, 'EUNIT_TEST', true}]}.
 
 {deps, [
-    {lager, ".*", {git, "git://github.com/basho/lager.git", "3.2.4"}},
-    {syslog, ".*", {git, "git://github.com/nivertech/erlang-syslog", "ori_070812"}},
-    {bbmustache, ".*", {git, "https://github.com/xmppjingle/bbmustache.git", "HEAD"}},
-    {covertool, ".*", {git, "git://github.com/idubrov/covertool.git", "HEAD"}},
-    {confetti, ".*", {git, "git://github.com/manuel-rubio/confetti.git", "v0.1.2"}},
-    {snatch, ".*", {git, "git://github.com/xmppjingle/snatch.git", "HEAD"}},
-    % only for test, don't include them in reltool
-    {meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.2"}},
-    %% documentation
-    {edown, ".*", {git, "https://github.com/uwiger/edown", master}}
+    {goldrush, {git, "https://github.com/DeadZen/goldrush.git", {tag, "0.1.9"}}},
+    {lager, {git, "https://github.com/erlang-lager/lager.git", {tag, "3.9.2"}}},
+    {bbmustache, {git, "https://github.com/soranoba/bbmustache.git", {tag, "v1.12.2"}}},
+    {p1_utils, {git, "https://github.com/processone/p1_utils.git", {tag, "1.0.25"}}},
+    {fast_xml, {git, "https://github.com/processone/fast_xml.git", {tag, "1.1.51"}}},
+    {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.9.2"}}}
 ]}.
 
-{plugins, [rebar_covertool]}.
-{export, "all.coverdata"}.
+{overrides, [
+    {override, lager, [
+        {deps, [{goldrush, {git, "https://github.com/DeadZen/goldrush.git", {tag, "0.1.9"}}}]}
+    ]},
+    {override, fast_xml, [
+        {deps, [{p1_utils, {git, "https://github.com/processone/p1_utils.git", {tag, "1.0.25"}}}]},
+        {plugins, []},
+        {provider_hooks, []}
+    ]},
+    {override, p1_utils, [
+        {plugins, []},
+        {provider_hooks, []}
+    ]}
+]}.
 
 {cover_enabled, true}.
 {cover_print_enable, true}.
 {cover_export_enabled, true}.
-{covertool_eunit, {".eunit/eunit.coverdata", "eunit.coverage.xml"}}.
-
- 

--- a/src/clexical.app.src
+++ b/src/clexical.app.src
@@ -1,7 +1,7 @@
 {application, clexical,
     [
         {description, "Clexical Event Driven Meta Evaluator"},
-        {vsn, git},
+        {vsn, "0.1.0"},
         {registered, []},
         {applications, [
             kernel,

--- a/src/clexical_utils.erl
+++ b/src/clexical_utils.erl
@@ -1,6 +1,6 @@
 -module(clexical_utils).
 
--include_lib("xmpp.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 
 -export([
     remove_whitespaces_deeply/1,

--- a/src/xmpp_herald.erl
+++ b/src/xmpp_herald.erl
@@ -1,6 +1,6 @@
 -module(xmpp_herald).
 -include("../include/clexical.hrl").
--include_lib("xmpp.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 -behaviour(gen_server).
 -behaviour(herald).
 -behaviour(xmpp_linguist).

--- a/src/xmpp_linguist.erl
+++ b/src/xmpp_linguist.erl
@@ -1,6 +1,6 @@
 -module(xmpp_linguist).
 -include("../include/clexical.hrl").
--include_lib("xmpp.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 
 -callback get_envelop_type(Envelop::#xmlel{}) -> decree|bulletin|undefined.
 

--- a/test/snatch_herald_test.erl
+++ b/test/snatch_herald_test.erl
@@ -5,24 +5,29 @@
 -include("../include/clexical_test.hrl").
 
 setup_test_() ->
-    application:start(xmpp),
     ?start_lager(),
     {setup,
         spawn,
         fun init_per_suite/0,
         fun end_per_suite/1,
-        [        
+        [
+            fun basic_parse_/0,
+            fun basic_cleanup_/0
         ]
     }.
 
 init_per_suite() ->
+    xmpp_herald:start_link([]),
     ok.
 
 end_per_suite(_Config) ->
-    meck:unload(),
+    gen_server:stop(xmpp_herald),
     ok.
 
-basic_parse_test() ->
+basic_parse_() ->
+    basic_parse_run().
+
+basic_parse_run() ->
     Bin = <<"<decree><offer id='1' subject='bestbuy' good='case'><onPurchase><celebrate/></onPurchase></offer></decree>">>,
     L = xmpp_herald:letter_from_binary(Bin),
     ?assert(L /= undefined),
@@ -33,7 +38,10 @@ basic_parse_test() ->
     K = xmpp_herald:excerpts(P),
     ?assert(K /= undefined).
 
-basic_cleanup_test() ->
+basic_cleanup_() ->
+    basic_cleanup_run().
+
+basic_cleanup_run() ->
     Bin = <<"<decree>
             <offer id='1' subject='bestbuy' good='case'>
                 <onPurchase>

--- a/test/xml_mnesia_scribe_test.erl
+++ b/test/xml_mnesia_scribe_test.erl
@@ -5,15 +5,18 @@
 -include("../include/clexical_test.hrl").
 
 setup_test_() ->
-    clexical_id:start_link([]),
-    clexical:start_link({xmpp_herald, []}, {mnesia_scribe, []}, {?MODULE, []}),
     ?start_lager(),
     ?start_apps(),
     {setup,
         spawn,
         fun init_per_suite/0,
         fun end_per_suite/1,
-        [        
+        [
+            fun basic_bear_in_mind_/0,
+            fun process_/0,
+            fun merge_adjectives_/0,
+            fun merge_adjectives_letters_/0,
+            fun merge_adjectives_letters_deep_/0
         ]
     }.
 
@@ -21,6 +24,11 @@ initialize(_) ->
     ok.
 
 init_per_suite() ->
+    application:start(mnesia),
+    clexical_id:start_link([]),
+    xmpp_herald:start_link([]),
+    mnesia_scribe:initialize([]),
+    clexical:start_link({xmpp_herald, []}, {mnesia_scribe, []}, {?MODULE, []}),
     ok.
 
 end_per_suite(_Config) ->
@@ -32,7 +40,10 @@ end_per_suite(_Config) ->
     gen_server:stop(clexical_id),
     ok.
 
-basic_bear_in_mind_test() ->
+basic_bear_in_mind_() ->
+    basic_bear_in_mind_run().
+
+basic_bear_in_mind_run() ->
 	#letter{predicates = [P|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><test1/><test2/></onOffer></iq>">>),
     lager:debug("P: ~p ~n", [P]),
 	K = clexical:compose_key(P),
@@ -40,26 +51,38 @@ basic_bear_in_mind_test() ->
 	PP = mnesia_scribe:recall(K),
     ?assertEqual(P, PP).
 
-process_test() ->
+process_() ->
+    process_run().
+
+process_run() ->
     xmpp_herald:process_letter(xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><test1/><test2/></onOffer></iq>">>)),
     timer:sleep(200),
     xmpp_herald:process_letter(xmpp_herald:letter_from_binary(<<"<presence id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'/></presence>">>)),   
     ?assertEqual(1, 1).
 
-merge_adjectives_test() ->
+merge_adjectives_() ->
+    merge_adjectives_run().
+
+merge_adjectives_run() ->
     #letter{predicates = [P|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><test1 a='a'/><test2 b='b'/></onOffer></iq>">>),
     M = xmpp_herald:merge_adjectives(P),
     lager:debug("M: ~p ~n", [M]),
     ?assertEqual(#{<<"a">> => <<"a">>,<<"b">> => <<"b">>,<<"id">> => <<"*ID*">>}, M).
 
-merge_adjectives_letters_test() ->
+merge_adjectives_letters_() ->
+    merge_adjectives_letters_run().
+
+merge_adjectives_letters_run() ->
     #letter{predicates = [P|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><test1 a='a'/><test2 b='b'/></onOffer></iq>">>),
     #letter{predicates = [PP|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><test1 c='c'/><test2 d='d'/></onOffer></iq>">>),
     MM = xmpp_herald:merge_adjectives(P, PP),
     lager:debug("MM: ~p ~n", [MM]),
     ?assertEqual(MM, #{<<"a">> => <<"a">>,<<"b">> => <<"b">>,<<"c">> => <<"c">>,<<"d">> => <<"d">>,<<"id">> => <<"*ID*">>}).
 
-merge_adjectives_letters_deep_test() ->
+merge_adjectives_letters_deep_() ->
+    merge_adjectives_letters_deep_run().
+
+merge_adjectives_letters_deep_run() ->
     #letter{predicates = [P|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><s><test1 a='a'/><p><test2 b='b'/></p></s></onOffer></iq>">>),
     #letter{predicates = [PP|_]} = xmpp_herald:letter_from_binary(<<"<iq id='", ?ANY_SUBJECT/binary, "'><onOffer id='", ?ANY_ID/binary, "'><s><test1 c='c'/><p><test2 d='d'/></p></s></onOffer></iq>">>),
     MM = xmpp_herald:merge_adjectives(P, PP),


### PR DESCRIPTION
- Convert from rebar2 to rebar3 build system
- Replace git:// URLs with https:// for all dependencies
- Update dependency versions (lager 3.9.2, meck 0.9.2, bbmustache v1.12.2)
- Replace xmpp.hrl includes with fast_xml/include/fxml.hrl (only xmlel record needed)
- Remove heavy xmpp dependency and its transitive deps (fast_tls, ezlib, idna, stringprep)
- Add local confetti stub app (mocked in tests, unavailable upstream)
- Fix test setup: start xmpp_herald gen_server before tests that need it
- Fix test setup: initialize mnesia tables before mnesia_scribe tests
- Move test functions into eunit setup generators for proper lifecycle
- Update .gitignore for rebar3 artifacts
- All 8 tests pass
